### PR TITLE
Fix JSON Serialisation Bug

### DIFF
--- a/CloudWatchLogs-Firehose-Resources/lambda.py
+++ b/CloudWatchLogs-Firehose-Resources/lambda.py
@@ -23,8 +23,18 @@ def handler(event, context):
 		for logEvent in decodedData['logEvents']:
 
 			# Format Splunk event
-			formattedEvents += '{ "time": ' +  str(logEvent['timestamp']) + ', "host": "' + SPLUNK_HOST + '", "source": "' + SPLUNK_SOURCE + '", "sourcetype": "' + SPLUNK_SOURCETYPE + '", "index": "' + SPLUNK_INDEX + '", "event": "' + " ".join(str(logEvent['message']).split()) + '"}'
-		
+			formattedEvents += json.dumps(
+				{
+					"time": logEvent["timestamp"],
+					"host": SPLUNK_HOST,
+					"source": SPLUNK_SOURCE,
+					"sourcetype": SPLUNK_SOURCETYPE,
+					"index": SPLUNK_INDEX,
+					"event": logEvent["message"],
+				},
+				indent=None,
+			)
+			
 		# Construct return event
 		returnEvent['recordId'] = dict(record)['recordId']
 		returnEvent['result'] = "Ok"


### PR DESCRIPTION
Splunk events in the CWL/Firehose Lambda are formatted using string interpolation which fails to serialise JSON control characters properly. Log events containing `\` or `"` will fail to parse correctly without escaping.

This PR uses `json.dumps()` to encode the output, matching the format by setting `indent=None`.