### PR TITLE
Fixed issue for when exactly 450 events were in a file to be processe…

### DIFF
--- a/S3-SQS-Lambda-Firehose-Resources/eventsInS3ToSplunk.yml
+++ b/S3-SQS-Lambda-Firehose-Resources/eventsInS3ToSplunk.yml
@@ -937,8 +937,8 @@ Resources:
             while sendingAttempt <= maxRetriesToFirehose:
 
               try:
-                # If there are more than 450 records or 4500000B in the sending queue, send the event to Splunk and clear the queue
-                if len(recordBatch) >= 450 or sys.getsizeof(recordBatch) >= 4500000 or final == True:
+                # If there are more than 450 records or 4500000B in the sending queue or this is the final sending and there are records to send, send the event to Splunk and clear the queue
+                if len(recordBatch) >= 450 or sys.getsizeof(recordBatch) >= 4500000 or (final == True and len(recordBatch) >= 1):
                   
                   # Incrmenet eventBatch for logging
                   if sendingAttempt == 1:
@@ -957,7 +957,10 @@ Resources:
 
                 # If the threshold for sending wasn't reached...
                 else:
-                  return("Event buffered")
+                  if (final == True and len(recordBatch) == 0):
+                    return("Final try, no events buffered")
+                  else: 
+                    return("Event buffered")
 
               # Print exception for debugging
               except Exception as e:
@@ -1068,10 +1071,6 @@ Resources:
 
               # Logging
               print("Processed file s3://" + objectInfo["bucket"] + "/" + objectInfo["key"])
-
-
-
-
       Description: Lambda function for processing SQS messages that contain events, then sending them to firehose to be forwarded to Splunk.
       Environment:
         Variables:

--- a/S3-SQS-Lambda-Firehose-Resources/lambda.py
+++ b/S3-SQS-Lambda-Firehose-Resources/lambda.py
@@ -288,8 +288,8 @@ def bufferAndSendEventsToFirehose(event, final, objectName, eventBatch):
 	while sendingAttempt <= maxRetriesToFirehose:
 
 		try:
-			# If there are more than 450 records or 4500000B in the sending queue, send the event to Splunk and clear the queue
-			if len(recordBatch) >= 450 or sys.getsizeof(recordBatch) >= 4500000 or final == True:
+			# If there are more than 450 records or 4500000B in the sending queue or this is the final sending and there are records to send, send the event to Splunk and clear the queue
+			if len(recordBatch) >= 450 or sys.getsizeof(recordBatch) >= 4500000 or (final == True and len(recordBatch) >= 1):
 				
 				# Incrmenet eventBatch for logging
 				if sendingAttempt == 1:
@@ -308,7 +308,10 @@ def bufferAndSendEventsToFirehose(event, final, objectName, eventBatch):
 
 			# If the threshold for sending wasn't reached...
 			else:
-				return("Event buffered")
+				if (final == True and len(recordBatch) == 0):
+					return("Final try, no events buffered")
+				else: 
+					return("Event buffered")
 
 		# Print exception for debugging
 		except Exception as e:

--- a/S3-SQS-Lambda-Firehose-Resources/tests.py
+++ b/S3-SQS-Lambda-Firehose-Resources/tests.py
@@ -407,6 +407,15 @@ class S3_SQS_Lambda_Firehose_Tests(unittest.TestCase):
 
 		self.assertEqual(str(file2), '{ "time": ' +  timestamp + ', "host": "moto-test-host-2", "source": "moto-test-source", "sourcetype": "moto-test-sourcetype", "index": "moto-test-index", "event":  "moto-test-event"}')
 
+		# Delete file in S3
+		s3Client.delete_object(Bucket=self.bucket_name_firehose, Key=firehoseKey)
+		self.assertEqual(dict(s3Client.list_objects_v2(Bucket=self.bucket_name_firehose))['KeyCount'], 0)
+
+		# Send zero events, final argument to true, then verify nothiing is being sent to S3
+		timestamp = str(round(time.time(), 2))
+		self.assertEqual(self.lambda_module.bufferAndSendEventsToFirehose('', True, "object1.tgz", [0]), "Final try, no events buffered")
+		self.assertEqual(dict(s3Client.list_objects_v2(Bucket=self.bucket_name_firehose))['KeyCount'], 0)
+
 
 	def test_integration_cloudtrail(self):
 


### PR DESCRIPTION
…d, and the Lambda function would retry sending 0 events to Firehose until it timed out or hit max retries.  And testing for this edge case. 

Or phrased differently: :fire::floppy_disk::sparkles: fixed a super niche bug where exactly 450 events in S3 would totally bork the Firehose send :man-facepalming::skull: added unit tests so this chaos won’t happen again :raised_hands: #blessed #codeislife